### PR TITLE
Bugfix, filter defaults and readme changes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM node:6
 
 COPY package.json /app/package.json
+WORKDIR /app
 RUN npm install
 
+COPY tsconfig.json /app/tsconfig.json
 COPY source/ /app/source/
 COPY tests/ /app/tests/
-WORKDIR /app
+COPY typings/ /app/typings/
 
 RUN npm run build
 
-ENTRYPOINT [ "npm", "run", "test" ]
+ENTRYPOINT [ "npm", "test" ]

--- a/README.md
+++ b/README.md
@@ -1,54 +1,101 @@
-# ethereumjs-blockstream
-
 [![Build Status](https://travis-ci.org/ethereumjs/ethereumjs-blockstream.svg?branch=master)](https://travis-ci.org/ethereumjs/ethereumjs-blockstream) [![Coverage Status](https://coveralls.io/repos/ethereumjs/ethereumjs-blockstream/badge.svg?branch=master&service=github)](https://coveralls.io/github/ethereumjs/ethereumjs-blockstream?branch=master) [![npm version](https://badge.fury.io/js/ethereumjs-blockstream.svg)](https://badge.fury.io/js/ethereumjs-blockstream)
 
-A library to turn an unreliable remote source of Ethereum blocks into a reliable stream of blocks.  Handles block and log removals on chain reorganizations as well as block and log backfills on skipped blocks.
+A library to turn an unreliable remote source of Ethereum blocks into a reliable stream of blocks.  Handles block and log removals on chain reorganization and block and log backfills on skipped blocks.
 
-## Usage
+# Usage
 
-ethereumjs-blockstream can be installed using npm:
-
+## Full Example
+```typescript
+// blockRetention is how many blocks of history to keep in memory.  it defaults to 100 if not supplied
+const configuration = { blockRetention: 100 };
+function getBlockByHash(hash: string): Promise<Block|null> {
+    return fetch("http://localhost:8545", {
+        method: "POST",
+        headers: new Headers({"Content-Type": "application/json"}),
+        body: { jsonrpc: "2.0", id: 1, method: "eth_getBlockByHash", params: [hash, false] }
+    }).then(response => response.json());
+}
+//function getBlockByHashCallbackStyle(hash: string, callback: (block: Block|null) => void): void {
+//    fetch("http://localhost:8545", {
+//        method: "POST",
+//        headers: new Headers({"Content-Type": "application/json"}),
+//        body: { jsonrpc: "2.0", id: 1, method: "eth_getBlockByHash", params: [hash, false] }
+//    })
+//    .then(response => response.json())
+//    .then(block => callback(undefined, block))
+//    .catch(error => callback(error, undefined));
+//}
+function getLogs(filterOptions: FilterOptions): Promise<Log[]> {
+    return fetch("http://localhost:8545", {
+        method: "POST",
+        headers: new Headers({"Content-Type": "application/json"}),
+        body: { jsonrpc: "2.0", id: 1, method: "eth_getLogs", params: [filterOptions] }
+    }).then(response => response.json());
+}
+//function getLogsCallbackStyle(filterOptions: FilterOptions): Promise<Log[]> {
+//    return fetch("http://localhost:8545", {
+//        method: "POST",
+//        headers: new Headers({"Content-Type": "application/json"}),
+//        body: { jsonrpc: "2.0", id: 1, method: "eth_getLogs", params: [filterOptions] }
+//    })
+//    .then(response => response.json())
+//    .then(logs => callback(undefined, logs)
+//    .catch(error => callback(error, undefined));
+//}
+function getLatestBlock(): Promise<Block> {
+    return fetch("http://localhost:8545", {
+        method: "POST",
+        headers: new Headers({"Content-Type": "application/json"}),
+        body: { jsonrpc: "2.0", id: 1, method: "eth_getBlockByNumber", params: ["latest", false] }
+    }).then(response => response.json());
+}
+const blockAndLogStreamer = new BlockAndLogStreamer(getBlockByHash, getLogs, configuration);
+// const blockAndLogStreamer = BlockAndLogStreamer.createCallbackStyle(getBlockByHashCallbackStyle, getLogsCallbackStyle, configuration);
+const onBlockAddedSubscriptionToken = blockAndLogStreamer.subscribeToOnBlockAdded(block => console.log(block));
+const onLogAddedSubscriptionToken = blockAndLogStreamer.subscribeToOnLogAdded(log => console.log(log));
+const onBlockRemovedSubscriptionToken = blockAndLogStreamer.subscribeToOnBlockRemoved(block => console.log(block));
+const onLogRemovedSubscriptionToken = blockAndLogStreamer.subscribeToOnLogRemoved(log => console.log(log));
+const logFilterToken = blockAndLogStreamer.addLogFilter({address: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", topics: ["0xbadf00dbadf00dbadf00dbadf00dbadf00dbadf00dbadf00dbadf00dbaadf00d"]});
+blockAndLogStreamer.reconcileNewBlock(getLatestBlock());
+// you will get a callback for the block and any logs that match the filter here
+triggerBlockMining();
+triggerBlockMining();
+triggerBlockMining();
+blockAndLogStreamer.reconcileNewBlock(getLatestBlock());
+// you will get a callback for all blocks and logs that match the filter that have been added to the chain since the previous call to reconcileNewBlock
+triggerChainReorg();
+blockAndLogStreamer.reconcileNewBlock(getLatestBlock());
+// you will get a callback for block/log removals that occurred due to the chain re-org, followed by block/log additions
+blockAndLogStreamer.unsubscribeFromOnBlockAdded(onBlockAddedSubscriptionToken);
+blockAndLogStreamer.unsubscribeFromOnBlockRemoved(onBlockRemovedSubscriptionToken);
+blockAndLogStreamer.unsubscribeFromOnLogAdded(onLogAddedSubscriptionToken);
+blockAndLogStreamer.unsubscribeFromOnLogRemoved(onLogRemovedSubscriptionToken);
+blockAndLogStreamer.removeLogFilter(logFilterToken);
+console.log(blockAndLogStreamer.getLatestReconciledBlock());
 ```
-npm install ethereumjs-blockstream
-```
 
-### [Instantiate](https://github.com/ethereumjs/ethereumjs-blockstream/blob/master/tests/index.ts#L466)
+## Signatures
+Note: if you have a TypeScript aware editor this will all be available in the tooltip
+* [Filter/FilterOptions](https://github.com/ethereumjs/ethereumjs-blockstream/blob/master/source/models/filters.ts#L1-L10) - More details at [Parity JSON-RPC Wiki](https://github.com/paritytech/parity/wiki/JSONRPC-eth-module#eth_newfilter)
+* [Block](https://github.com/ethereumjs/ethereumjs-blockstream/blob/master/source/models/block.ts#L3-L22) - More details at [Parity JSON-RPC Wiki](https://github.com/paritytech/parity/wiki/JSONRPC-eth-module#eth_getblockbyhash)
+* [Log](https://github.com/ethereumjs/ethereumjs-blockstream/blob/master/source/models/log.ts#L1-L10) - More details at [Parity JSON-RPC Wiki](https://github.com/paritytech/parity/wiki/JSONRPC-eth-module#eth_getfilterchanges)
 
-```javascript
-new BlockAndLogStreamer(getBlockByHashFunction, getLogsFunction, { blockRetention: 5 });
-```
-
-### [Subscribe](https://github.com/ethereumjs/ethereumjs-blockstream/blob/master/tests/index.ts#L467-L470)
-
-```javascript
-blockAndLogStreamer.subscribeToOnLogAdded(onLogAddedCallback);
-```
-
-### [Reconcile New Blocks](https://github.com/ethereumjs/ethereumjs-blockstream/blob/master/tests/index.ts#L512-L514)
-
-```javascript
-blockAndLogStreamer.reconcileNewBlock(blockFromGetLatest);
-```
+# Development
 
 ## Build
-
-```
-npm run build
-```
-To build using Docker:
-
 ```
 docker build -t blockstream .
 ```
+or
+```
+npm run build
+```
 
 ## Test
-
-```
-npm run test
-```
-
-To run tests using Docker:
-
 ```
 docker run blockstream
+````
+or
+```
+npm run test
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ function getBlockByHash(hash: string): Promise<Block|null> {
         body: { jsonrpc: "2.0", id: 1, method: "eth_getBlockByHash", params: [hash, false] }
     }).then(response => response.json());
 }
-//function getBlockByHashCallbackStyle(hash: string, callback: (block: Block|null) => void): void {
+//function getBlockByHashCallbackStyle(hash: string, callback: (error: Error, block?: Block) => void): void {
 //    fetch("http://localhost:8545", {
 //        method: "POST",
 //        headers: new Headers({"Content-Type": "application/json"}),
@@ -32,7 +32,7 @@ function getLogs(filterOptions: FilterOptions): Promise<Log[]> {
         body: { jsonrpc: "2.0", id: 1, method: "eth_getLogs", params: [filterOptions] }
     }).then(response => response.json());
 }
-//function getLogsCallbackStyle(filterOptions: FilterOptions): Promise<Log[]> {
+//function getLogsCallbackStyle(filterOptions: FilterOptions, callback: (error: Error, logs?: Log[]) => void): void {
 //    return fetch("http://localhost:8545", {
 //        method: "POST",
 //        headers: new Headers({"Content-Type": "application/json"}),

--- a/source/block-and-log-streamer.ts
+++ b/source/block-and-log-streamer.ts
@@ -17,7 +17,7 @@ export class BlockAndLogStreamer {
 	private readonly blockRetention: number;
 
 	private readonly getBlockByHash: (hash: string) => Promise<Block | null>;
-	private readonly getLogs: (filterOptions: FilterOptions[]) => Promise<Log[]>;
+	private readonly getLogs: (filterOptions: FilterOptions) => Promise<Log[]>;
 
 	private readonly logFilters: { [propName: string]: Filter } = {}
 	private readonly onBlockAddedSubscribers: { [propName: string]: (block: Block) => void } = {};
@@ -27,7 +27,7 @@ export class BlockAndLogStreamer {
 
 	constructor(
 		getBlockByHash: (hash: string) => Promise<Block | null>,
-		getLogs: (filterOptions: FilterOptions[]) => Promise<Log[]>,
+		getLogs: (filterOptions: FilterOptions) => Promise<Log[]>,
 		configuration?: { blockRetention?: number },
 	) {
 		this.getBlockByHash = getBlockByHash;
@@ -37,7 +37,7 @@ export class BlockAndLogStreamer {
 
 	static createCallbackStyle = (
 		getBlockByHash: (hash: string, callback: (error?: Error, block?: Block | null) => void) => void,
-		getLogs: (filterOptions: FilterOptions[], callback: (error?: Error, logs?: Log[]) => void) => void,
+		getLogs: (filterOptions: FilterOptions, callback: (error?: Error, logs?: Log[]) => void) => void,
 		configuration?: { blockRetention?: number },
 	): BlockAndLogStreamer => {
 		const wrappedGetBlockByHash = (hash: string): Promise<Block | null> => new Promise<Block | null>((resolve, reject) => {
@@ -46,7 +46,7 @@ export class BlockAndLogStreamer {
 				else resolve(block);
 			});
 		});
-		const wrappedGetLogs = (filterOptions: FilterOptions[]): Promise<Log[]> => new Promise<Log[]>((resolve, reject) => {
+		const wrappedGetLogs = (filterOptions: FilterOptions): Promise<Log[]> => new Promise<Log[]>((resolve, reject) => {
 			getLogs(filterOptions, (error, logs) => {
 				if (error) throw error;
 				if (!logs) throw new Error("Received null/undefined logs and no error.");

--- a/tests/es5.js
+++ b/tests/es5.js
@@ -7,7 +7,7 @@ var getBlockByHashFactory = require("./helpers").getBlockByHashFactory;
 var getLogsFactory = require("./helpers").getLogsFactory;
 var expect = require("chai").expect;
 
-describe("BlockAndLogStreamer", function () {
+describe("BlockAndLogStreamer Callback Style", function () {
   var blockAndLogStreamer;
   var blockAddedAnnouncements;
   var blockRemovedAnnouncements;
@@ -32,6 +32,7 @@ describe("BlockAndLogStreamer", function () {
         .catch(error => callback(error, undefined));
     };
     blockAndLogStreamer = BlockAndLogStreamer.createCallbackStyle(wrappedGetBlockByHash, wrappedGetLogs, { blockRetention: 5 });
+		blockAndLogStreamer.addLogFilter({});
     blockAndLogStreamer.subscribeToOnBlockAdded(onBlockAdded);
     blockAndLogStreamer.subscribeToOnBlockRemoved(onBlockRemoved);
     blockAndLogStreamer.subscribeToOnLogAdded(onLogAdded);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -18,15 +18,13 @@ export function getBlockByHashFactory(blocks: Block[] = []) {
 }
 
 export function getLogsFactory(logsPerFilter: number, fork: string = "AAAA") {
-	return async (filterOptions: FilterOptions[]): Promise<Log[]> => {
+	return async (filterOptions: FilterOptions): Promise<Log[]> => {
 		await delay(0);
-		if (filterOptions.length === 0) throw new Error("filter options are required");
+		if (!filterOptions) throw new Error("filter options are required");
 		const logs = [];
 		let logIndex = 0;
 		for (let i = 0; i < logsPerFilter; ++i) {
-			for (const filter of filterOptions) {
-				logs.push(new MockLog(parseInt(filter.toBlock!, 16), logIndex++, fork));
-			}
+			logs.push(new MockLog(parseInt(filterOptions.toBlock!, 16), logIndex++, fork));
 		}
 		return logs;
 	};


### PR DESCRIPTION
Fixes a bug where filters weren't being passed to RPC correctly.

Changes default to no filters (meaning no logs) rather than defaulting to a filter that includes all logs.

Updates readme with full example.