### PR TITLE
Adds support for a wider variety of Block and Log models.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: false
 language: node_js
 
 node_js:
-  - "7"
-  - "6"
+  - "8"
 
 before_script:
   - npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,9 +26,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.0.57",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.57.tgz",
-      "integrity": "sha512-ZxrhcBxlZA7tn0HFf7ebUYfR9aHyBgjyavBLzyrYMYuAMbONBPY4S5O35562iV2FfwnZCjQky3gTDy1B3jSZ2Q==",
+      "version": "8.0.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
+      "integrity": "sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ==",
       "dev": true
     },
     "@types/source-map-support": {
@@ -37,7 +37,7 @@
       "integrity": "sha1-zmSX36nJ+9IadTlVtKUdiZPXWd0=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.57"
+        "@types/node": "8.0.53"
       }
     },
     "@types/uuid": {
@@ -46,7 +46,7 @@
       "integrity": "sha1-k5oZirc1Z/gRq4T2cNK+nCWt3UE=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.57"
+        "@types/node": "8.0.53"
       }
     },
     "abbrev": {
@@ -276,9 +276,9 @@
       }
     },
     "commander": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "concat-map": {
@@ -593,7 +593,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "commander": "2.12.2",
+        "commander": "2.11.0",
         "is-my-json-valid": "2.16.1",
         "pinkie-promise": "2.0.1"
       }
@@ -643,9 +643,9 @@
       }
     },
     "immutable": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
-      "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI="
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
     },
     "inflight": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "2.2.2"
   },
   "dependencies": {
-    "immutable": "3.8.1",
+    "immutable": "3.8.2",
     "source-map-support": "0.4.14",
     "uuid": "3.0.1"
   }

--- a/source/block-reconciler.ts
+++ b/source/block-reconciler.ts
@@ -2,14 +2,16 @@ import { Block } from "./models/block";
 import { BlockHistory } from "./models/block-history";
 import { List as ImmutableList } from "immutable";
 
-export const reconcileBlockHistory = async (
-	getBlockByHash: (hash: string) => Promise<Block|null>,
-	blockHistory: BlockHistory|Promise<BlockHistory>,
-	newBlock: Block,
-	onBlockAdded: (block: Block) => Promise<void>,
-	onBlockRemoved: (block: Block) => Promise<void>,
+type GetBlockByHash<TBlock> = (hash: string) => Promise<TBlock|null>;
+
+export const reconcileBlockHistory = async <TBlock extends Block>(
+	getBlockByHash: GetBlockByHash<TBlock>,
+	blockHistory: BlockHistory<TBlock>|Promise<BlockHistory<TBlock>>,
+	newBlock: TBlock,
+	onBlockAdded: (block: TBlock) => Promise<void>,
+	onBlockRemoved: (block: TBlock) => Promise<void>,
 	blockRetention: number = 100,
-): Promise<BlockHistory> => {
+): Promise<BlockHistory<TBlock>> => {
 	blockHistory = await blockHistory;
 	if (isFirstBlock(blockHistory))
 		return await addNewHeadBlock(blockHistory, newBlock, onBlockAdded, blockRetention);
@@ -30,7 +32,7 @@ export const reconcileBlockHistory = async (
 	return await backfill(getBlockByHash, blockHistory, newBlock, onBlockAdded, onBlockRemoved, blockRetention);
 }
 
-const rollback = async (blockHistory: BlockHistory, onBlockRemoved: (block: Block) => Promise<void>): Promise<BlockHistory> => {
+const rollback = async <TBlock extends Block>(blockHistory: BlockHistory<TBlock>, onBlockRemoved: (block: TBlock) => Promise<void>): Promise<BlockHistory<TBlock>> => {
 	while (!blockHistory.isEmpty()) {
 		// CONSIDER: if this throws an exception, removals may have been announced that are actually still in history since throwing will result in no history update. we can't catch errors here because there isn't a clear way to recover from them, the failure may be a downstream system telling us that the block removal isn't possible because they are in a bad state. we could try re-announcing the successfully added blocks, but there would still be a problem with the failed block (should it be re-announced?) and the addition announcements may also fail
 		blockHistory = await removeHeadBlock(blockHistory, onBlockRemoved);
@@ -38,7 +40,7 @@ const rollback = async (blockHistory: BlockHistory, onBlockRemoved: (block: Bloc
 	return blockHistory;
 }
 
-const backfill = async (getBlockByHash: (hash: string) => Promise<Block|null>, blockHistory: BlockHistory, newBlock: Block, onBlockAdded: (block: Block) => Promise<void>, onBlockRemoved: (block: Block) => Promise<void>, blockRetention: number) => {
+const backfill = async <TBlock extends Block>(getBlockByHash: GetBlockByHash<TBlock>, blockHistory: BlockHistory<TBlock>, newBlock: TBlock, onBlockAdded: (block: TBlock) => Promise<void>, onBlockRemoved: (block: TBlock) => Promise<void>, blockRetention: number) => {
 	if (newBlock.parentHash === "0x0000000000000000000000000000000000000000000000000000000000000000")
 		return rollback(blockHistory, onBlockRemoved);
 	const parentBlock = await getBlockByHash(newBlock.parentHash);
@@ -49,36 +51,36 @@ const backfill = async (getBlockByHash: (hash: string) => Promise<Block|null>, b
 	return await reconcileBlockHistory(getBlockByHash, blockHistory, newBlock, onBlockAdded, onBlockRemoved, blockRetention);
 }
 
-const addNewHeadBlock = async (blockHistory: BlockHistory, newBlock: Block, onBlockAdded: (block: Block) => Promise<void>, blockRetention: number): Promise<BlockHistory> => {
+const addNewHeadBlock = async <TBlock extends Block>(blockHistory: BlockHistory<TBlock>, newBlock: TBlock, onBlockAdded: (block: TBlock) => Promise<void>, blockRetention: number): Promise<BlockHistory<TBlock>> => {
 	// this is here as a final sanity check, in case we somehow got into an unexpected state, there are no known (and should never be) ways to reach this exception
 	if (!blockHistory.isEmpty() && blockHistory.last().hash !== newBlock.parentHash) throw new Error("New head block's parent isn't our current head.");
-	// CONSIDER: the user getting this notification won't have any visibility into the updated block history yet. should we announce new blocks in a `setTimeout`? should we provide block history with new logs? an announcement failure will result in unwinding the stack and returning the original blockHistory, if we are in the process of backfilling we may have already announced previous blocks that won't actually end up in history (they won't get removed if a re-org occurs and may be re-announced). we can't catch errors thrown by the callback be cause it may be trying to signal to use that the block has become invalid and is un-processable
+	// CONSIDER: the user getting this notification won't have any visibility into the updated block history yet. should we announce new blocks in a `setTimeout`? should we provide block history with new logs? an announcement failure will result in unwinding the stack and returning the original blockHistory, if we are in the process of backfilling we may have already announced previous blocks that won't actually end up in history (they won't get removed if a re-org occurs and may be re-announced). we can't catch errors thrown by the callback because it may be trying to signal to use that the block has become invalid and is un-processable
 	await onBlockAdded(newBlock);
 	blockHistory = blockHistory.push(newBlock);
 	return blockHistory.takeLast(blockRetention).toList();
 }
 
-const removeHeadBlock = async (blockHistory: BlockHistory, onBlockRemoved: (block: Block) => Promise<void>): Promise<BlockHistory> => {
+const removeHeadBlock = async <TBlock extends Block>(blockHistory: BlockHistory<TBlock>, onBlockRemoved: (block: TBlock) => Promise<void>): Promise<BlockHistory<TBlock>> => {
 	let removedBlock = blockHistory.last();
 	blockHistory = blockHistory.pop();
 	await onBlockRemoved(removedBlock);
 	return blockHistory;
 }
 
-const isFirstBlock = (blockHistory: BlockHistory, ): boolean => {
+const isFirstBlock = <TBlock extends Block>(blockHistory: BlockHistory<TBlock>, ): boolean => {
 	return blockHistory.isEmpty();
 }
 
-const isAlreadyInHistory = (blockHistory: BlockHistory, newBlock: Block): boolean => {
+const isAlreadyInHistory = <TBlock extends Block>(blockHistory: BlockHistory<TBlock>, newBlock: TBlock): boolean => {
 	// `block!` is required until the next version of `immutable` is published to NPM (current version 3.8.1) which improves the type definitions
 	return blockHistory.some(block => block!.hash === newBlock.hash);
 }
 
-const isNewHeadBlock = (blockHistory: BlockHistory, newBlock: Block): boolean => {
+const isNewHeadBlock = <TBlock extends Block>(blockHistory: BlockHistory<TBlock>, newBlock: TBlock): boolean => {
 	return blockHistory.last().hash === newBlock.parentHash;
 }
 
-const parentHashIsInHistory = (blockHistory: BlockHistory, newBlock: Block): boolean => {
+const parentHashIsInHistory = <TBlock extends Block>(blockHistory: BlockHistory<TBlock>, newBlock: TBlock): boolean => {
 	// `block!` is required until the next version of `immutable` is published to NPM (current version 3.8.1) which improves the type definitions
 	return blockHistory.some(block => block!.hash === newBlock.parentHash);
 }

--- a/source/models/block-history.ts
+++ b/source/models/block-history.ts
@@ -1,4 +1,4 @@
 import { Block } from "./block";
 import { List as ImmutableList } from "immutable";
 
-export type BlockHistory = ImmutableList<Block>;
+export type BlockHistory<TBlock extends Block> = ImmutableList<TBlock>;

--- a/source/models/block.ts
+++ b/source/models/block.ts
@@ -4,19 +4,4 @@ export interface Block {
 	readonly number: string;
 	readonly hash: string;
 	readonly parentHash: string;
-	readonly nonce: string;
-	readonly sha3Uncles: string;
-	readonly logsBloom: string;
-	readonly transactionRoot: string;
-	readonly stateRoot: string;
-	readonly receiptsRoot: string;
-	readonly miner: string;
-	readonly difficulty: string;
-	readonly totalDifficulty: string;
-	readonly size: string;
-	readonly gasLimit: string;
-	readonly gasUsed: string;
-	readonly timestamp: string;
-	readonly transactions: string[] | Transaction[];
-	readonly uncles: string[];
 }

--- a/source/models/log-history.ts
+++ b/source/models/log-history.ts
@@ -1,4 +1,4 @@
 import { Log } from "./log";
 import { List as ImmutableList } from "immutable";
 
-export type LogHistory = ImmutableList<Log>;
+export type LogHistory<TLog extends Log> = ImmutableList<TLog>;

--- a/source/models/log.ts
+++ b/source/models/log.ts
@@ -2,9 +2,4 @@ export interface Log {
 	readonly logIndex: string,
 	readonly blockNumber: string,
 	readonly blockHash: string,
-	readonly transactionHash: string,
-	readonly transactionIndex: string,
-	readonly address: string,
-	readonly data: string, 
-	readonly topics: string[],
 }

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -465,7 +465,7 @@ describe("reconcileLogHistoryWithRemovedBlock", async () => {
 });
 
 describe("BlockAndLogStreamer", async () => {
-	let blockAndLogStreamer: BlockAndLogStreamer;
+	let blockAndLogStreamer: BlockAndLogStreamer<Block, Log>;
 	let blockAddedAnnouncements: Block[];
 	let blockRemovedAnnouncements: Block[];
 	let logAddedAnnouncements: Log[];


### PR DESCRIPTION
Depending on the library you are using to provide blocks/logs to blockstream, your Block and Log model may not align exactly with the model this library was using.  Now as long as you meet some very basic minimum interface requirements you can use any Block/Log model you want.