### PR TITLE
Adds support for deduping logs.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockstream",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockstream",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "A library to turn an unreliable remote source of Ethereum blocks into a reliable stream of blocks with removals on re-orgs and backfills on skips.",
   "main": "output/source/index.js",
   "types": "output/source/index.d.ts",


### PR DESCRIPTION
Multiple filters can return the same log, so we need to dedupe logs rather than throwing.  This is a breaking change because we previously had documented behavior that duplicate logs would throw, whereas now we just assert that if the block hash and index are the same, then the log is the same.

Fixes #7 