### PR TITLE
Deprecates callback style interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,49 +8,31 @@ A library to turn an unreliable remote source of Ethereum blocks into a reliable
 ```typescript
 // blockRetention is how many blocks of history to keep in memory.  it defaults to 100 if not supplied
 const configuration = { blockRetention: 100 };
-function getBlockByHash(hash: string): Promise<Block|null> {
-    return fetch("http://localhost:8545", {
+async function getBlockByHash(hash: string): Promise<Block|null> {
+    const response = await fetch("http://localhost:8545", {
         method: "POST",
         headers: new Headers({"Content-Type": "application/json"}),
         body: { jsonrpc: "2.0", id: 1, method: "eth_getBlockByHash", params: [hash, false] }
-    }).then(response => response.json());
+    });
+    return await response.json();
 }
-//function getBlockByHashCallbackStyle(hash: string, callback: (error?: Error, block?: Block|null) => void): void {
-//    fetch("http://localhost:8545", {
-//        method: "POST",
-//        headers: new Headers({"Content-Type": "application/json"}),
-//        body: { jsonrpc: "2.0", id: 1, method: "eth_getBlockByHash", params: [hash, false] }
-//    })
-//    .then(response => response.json())
-//    .then(block => callback(undefined, block))
-//    .catch(error => callback(error, undefined));
-//}
-function getLogs(filterOptions: FilterOptions): Promise<Log[]> {
-    return fetch("http://localhost:8545", {
+async function getLogs(filterOptions: FilterOptions): Promise<Log[]> {
+    const response = await fetch("http://localhost:8545", {
         method: "POST",
         headers: new Headers({"Content-Type": "application/json"}),
         body: { jsonrpc: "2.0", id: 1, method: "eth_getLogs", params: [filterOptions] }
-    }).then(response => response.json());
+    });
+    return await response.json();
 }
-//function getLogsCallbackStyle(filterOptions: FilterOptions, callback: (error?: Error, logs?: Log[]) => void): void {
-//    return fetch("http://localhost:8545", {
-//        method: "POST",
-//        headers: new Headers({"Content-Type": "application/json"}),
-//        body: { jsonrpc: "2.0", id: 1, method: "eth_getLogs", params: [filterOptions] }
-//    })
-//    .then(response => response.json())
-//    .then(logs => callback(undefined, logs)
-//    .catch(error => callback(error, undefined));
-//}
-function getLatestBlock(): Promise<Block> {
-    return fetch("http://localhost:8545", {
+async function getLatestBlock(): Promise<Block> {
+    const response = await fetch("http://localhost:8545", {
         method: "POST",
         headers: new Headers({"Content-Type": "application/json"}),
         body: { jsonrpc: "2.0", id: 1, method: "eth_getBlockByNumber", params: ["latest", false] }
-    }).then(response => response.json());
+    });
+    return await response.json();
 }
 const blockAndLogStreamer = new BlockAndLogStreamer(getBlockByHash, getLogs, configuration);
-// const blockAndLogStreamer = BlockAndLogStreamer.createCallbackStyle(getBlockByHashCallbackStyle, getLogsCallbackStyle, configuration);
 const onBlockAddedSubscriptionToken = blockAndLogStreamer.subscribeToOnBlockAdded(block => console.log(block));
 const onLogAddedSubscriptionToken = blockAndLogStreamer.subscribeToOnLogAdded(log => console.log(log));
 const onBlockRemovedSubscriptionToken = blockAndLogStreamer.subscribeToOnBlockRemoved(block => console.log(block));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockstream",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockstream",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A library to turn an unreliable remote source of Ethereum blocks into a reliable stream of blocks with removals on re-orgs and backfills on skips.",
   "main": "output/source/index.js",
   "types": "output/source/index.d.ts",

--- a/source/block-and-log-streamer.ts
+++ b/source/block-and-log-streamer.ts
@@ -40,6 +40,7 @@ export class BlockAndLogStreamer<TBlock extends Block, TLog extends Log> {
 		getLogs: (filterOptions: FilterOptions, callback: (error?: Error, logs?: TLog[]) => void) => void,
 		configuration?: { blockRetention?: number },
 	): BlockAndLogStreamer<TBlock, TLog> => {
+		console.warn(`Deprecation Warning: The callback interface for ethereumjs-blockstream is deprecated and will be removed in a future version of this library.  Use BlockAndLogStreamer constructor instead.`);
 		const wrappedGetBlockByHash = (hash: string): Promise<TBlock | null> => {
 			return new Promise<TBlock | null>((resolve, reject) => {
 				getBlockByHash(hash, (error, block) => {
@@ -65,6 +66,7 @@ export class BlockAndLogStreamer<TBlock extends Block, TLog extends Log> {
 	};
 
 	public readonly reconcileNewBlockCallbackStyle = async (block: TBlock, callback: (error?: Error) => void): Promise<void> => {
+		console.warn(`Deprecation Warning: The callback interface for ethereumjs-blockstream is deprecated and will be removed in a future version of this library.  Use BlockAndLogStreamer.reconcileNewBlock instead.`);
 		this.reconcileNewBlock(block)
 			.then(() => callback(undefined))
 			.catch(error => callback(error));


### PR DESCRIPTION
Gets rid of the legacy style examples and adds a deprecation warning to the callback style entrypoints.

If you want callback style, use one of the many promise<->callback wrappers on the internet (though I strongly recommend just using async/await instead).

This change is being made because maintaining two interfaces is more expensive than maintaining one, and the legacy interface really shouldn't be used now that async/await is available everywhere (all major browsers and LTS version of NodeJS).