### PR TITLE
Switches to using new eth_getLogs by blockHash RPC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A library to turn an unreliable remote source of Ethereum blocks into a reliable stream of blocks.  Handles block and log removals on chain reorganization and block and log backfills on skipped blocks.
 
+# Requirements for supported Ethereum node
+Blockstream requires support for [EIP-234](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-234.md) in the configured Ethereum node. EIP-234 was merged Jul 28, 2018 and implemented in Geth and Parity shortly after. Versions that provide the needed functionality:
+- Parity: v2.1.0+
+- geth: v1.8.13+
+
 # Usage
 
 ## Full Example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockstream",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockstream",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockstream",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "A library to turn an unreliable remote source of Ethereum blocks into a reliable stream of blocks with removals on re-orgs and backfills on skips.",
   "main": "output/source/index.js",
   "types": "output/source/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockstream",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "A library to turn an unreliable remote source of Ethereum blocks into a reliable stream of blocks with removals on re-orgs and backfills on skips.",
   "main": "output/source/index.js",
   "types": "output/source/index.d.ts",

--- a/source/block-reconciler.ts
+++ b/source/block-reconciler.ts
@@ -1,5 +1,6 @@
 import { Block } from "./models/block";
 import { BlockHistory } from "./models/block-history";
+import { parseHexInt } from "./utilities";
 import { List as ImmutableList } from "immutable";
 
 type GetBlockByHash<TBlock> = (hash: string) => Promise<TBlock|null>;
@@ -50,7 +51,7 @@ const backfill = async <TBlock extends Block>(getBlockByHash: GetBlockByHash<TBl
 		return await rollback(blockHistory, onBlockRemoved);
 	const parentBlock = await getBlockByHash(newBlock.parentHash);
 	if (parentBlock === null) throw new Error("Failed to fetch parent block.");
-	if (parseInt(parentBlock.number, 16) + blockRetention < parseInt(blockHistory.last().number, 16))
+	if (parseHexInt(parentBlock.number) + blockRetention < parseHexInt(blockHistory.last().number))
 		return await rollback(blockHistory, onBlockRemoved);
 	blockHistory = await reconcileBlockHistory(getBlockByHash, blockHistory, parentBlock, onBlockAdded, onBlockRemoved, blockRetention);
 	return await reconcileBlockHistory(getBlockByHash, blockHistory, newBlock, onBlockAdded, onBlockRemoved, blockRetention);
@@ -77,7 +78,7 @@ const isFirstBlock = <TBlock extends Block>(blockHistory: BlockHistory<TBlock>):
 }
 
 const isOlderThanOldestBlock = <TBlock extends Block>(blockHistory: BlockHistory<TBlock>, newBlock: TBlock): boolean => {
-	return parseInt(blockHistory.first().number, 16) > parseInt(newBlock.number, 16);
+	return parseHexInt(blockHistory.first().number) > parseHexInt(newBlock.number);
 }
 
 const isAlreadyInHistory = <TBlock extends Block>(blockHistory: BlockHistory<TBlock>, newBlock: TBlock): boolean => {

--- a/source/models/filters.ts
+++ b/source/models/filters.ts
@@ -4,6 +4,5 @@ export interface Filter {
 }
 
 export interface FilterOptions extends Filter {
-	readonly fromBlock?: string;
-	readonly toBlock?: string;
+	readonly blockHash: string
 }

--- a/source/utilities.ts
+++ b/source/utilities.ts
@@ -1,0 +1,5 @@
+export const parseHexInt = (value: string) => {
+	const result = Number.parseInt(value, 16);
+	if (!Number.isFinite(result)) throw new Error(`${value} is not a hex encoded integer, parsing returned ${result}.`);
+	return result;
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -24,8 +24,8 @@ export function getLogsFactory(logsPerFilter: number, fork: string = "AAAA") {
 		const logs = [];
 		let logIndex = 0;
 		for (let i = 0; i < logsPerFilter; ++i) {
-			const blockNumber = parseInt(filterOptions.toBlock!, 16);
-			logs.push(new MockLog(blockNumber, logIndex++, fork));
+			const blockHash = filterOptions.blockHash;
+			logs.push(new MockLog(blockHash, logIndex++, fork));
 		}
 		return logs;
 	};
@@ -71,10 +71,10 @@ export class MockLog implements Log {
 	readonly data: string = "0x0000000000000000000000000000000000000000000000000000000000000000";
 	readonly topics: string[] = [];
 
-	constructor(blockNumber: number, logIndex: number = 0x0, fork: string = "AAAA") {
-		const blockNumberAsHex = blockNumber.toString(16);
-		this.blockNumber = "0x" + blockNumberAsHex;
-		this.blockHash = `0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0c${fork}${("0000" + blockNumberAsHex).substring(blockNumberAsHex.length)}`;
+	constructor(blockHash: string, logIndex: number = 0x0, fork: string = "AAAA") {
+		const blockNumber = parseInt(blockHash.substring(62), 16);
+		this.blockNumber = `0x${blockNumber.toString(16)}`;
+		this.blockHash = blockHash;
 		this.logIndex = `0x${logIndex.toString(16)}`;
 		this.transactionIndex = this.logIndex;
 	}

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -261,8 +261,8 @@ describe("reconcileLogHistoryWithAddedBlock", async () => {
 		const newLogHistory = await reconcileLogHistoryWithAddedBlock(getLogs, oldLogHistory, newBlock, onLogAdded, [{}]);
 
 		// unfortunately, because we have an immutable list of a complex object with a nested list of a complex object in it, we can't do a normal equality comparison
-		expect(newLogHistory.toJS()).to.deep.equal([new MockLog(0x7777)]);
-		expect(newLogAnnouncements).to.deep.equal([new MockLog(0x7777)]);
+		expect(newLogHistory.toJS()).to.deep.equal([new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777')]);
+		expect(newLogAnnouncements).to.deep.equal([new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777')]);
 	});
 
 	it("adds block with multiple logs", async () => {
@@ -274,21 +274,21 @@ describe("reconcileLogHistoryWithAddedBlock", async () => {
 
 		// unfortunately, because we have an immutable list of a complex object with a nested list of a complex object in it, we can't do a normal equality comparison
 		expect(newLogHistory.toJS()).to.deep.equal([
-			new MockLog(0x7777, 0x0),
-			new MockLog(0x7777, 0x1),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x0),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x1),
 		]);
 		expect(newLogAnnouncements).to.deep.equal([
-			new MockLog(0x7777, 0x0),
-			new MockLog(0x7777, 0x1),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x0),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x1),
 		]);
 	});
 
 	it("orders logs by index", async () => {
 		const getLogs = async (filterOptions: FilterOptions) => Promise.resolve([
-			new MockLog(0x7777, 0x1),
-			new MockLog(0x7777, 0x2),
-			new MockLog(0x7777, 0x0),
-			new MockLog(0x7777, 0x3),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x1),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x2),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x0),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x3),
 		]);
 		const newBlock = new MockBlock(0x7777);
 		const oldLogHistory = Promise.resolve(ImmutableList<Log>());
@@ -296,16 +296,16 @@ describe("reconcileLogHistoryWithAddedBlock", async () => {
 		const newLogHistory = await reconcileLogHistoryWithAddedBlock(getLogs, oldLogHistory, newBlock, onLogAdded, [{}]);
 
 		expect(newLogHistory.toJS()).to.deep.equal([
-			new MockLog(0x7777, 0x0),
-			new MockLog(0x7777, 0x1),
-			new MockLog(0x7777, 0x2),
-			new MockLog(0x7777, 0x3),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x0),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x1),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x2),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x3),
 		]);
 		expect(newLogAnnouncements).to.deep.equal([
-			new MockLog(0x7777, 0x0),
-			new MockLog(0x7777, 0x1),
-			new MockLog(0x7777, 0x2),
-			new MockLog(0x7777, 0x3),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x0),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x1),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x2),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x3),
 		]);
 	});
 
@@ -342,13 +342,13 @@ describe("reconcileLogHistoryWithAddedBlock", async () => {
 
 		await expect(secondLogHistoryPromise).to.eventually.rejectedWith(Error, /received log for a block (.*?) older than current head log's block (.*?)/);
 		// unfortunate reality
-		expect(newLogAnnouncements).to.deep.equal([new MockLog(0x7777)]);
+		expect(newLogAnnouncements).to.deep.equal([new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777')]);
 	})
 
 	it("dedupes logs with same blockhash and index from multiple filters", async () => {
 		const getLogs = async (filterOptions: FilterOptions) => Promise.resolve([
-			new MockLog(0x7777, 0x0),
-			new MockLog(0x7777, 0x1),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x0),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x1),
 		]);
 		const newBlock = new MockBlock(0x7777);
 		const oldLogHistory = Promise.resolve(ImmutableList<Log>());
@@ -356,8 +356,8 @@ describe("reconcileLogHistoryWithAddedBlock", async () => {
 		const newLogHistory = await reconcileLogHistoryWithAddedBlock(getLogs, oldLogHistory, newBlock, onLogAdded, [{},{}]);
 
 		expect(newLogAnnouncements).to.deep.equal([
-			new MockLog(0x7777, 0x0),
-			new MockLog(0x7777, 0x1),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x0),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x1),
 		]);
 	});
 
@@ -399,61 +399,61 @@ describe("reconcileLogHistoryWithRemovedBlock", async () => {
 
 	it("handles block removal with no associated logs", async () => {
 		const removedBlock = new MockBlock(0x7777);
-		const oldLogHistory = Promise.resolve(ImmutableList<Log>([new MockLog(0x7776)]));
+		const oldLogHistory = Promise.resolve(ImmutableList<Log>([new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7776')]));
 
 		const newLogHistory = await reconcileLogHistoryWithRemovedBlock(oldLogHistory, removedBlock, onLogRemoved);
 
-		expect(newLogHistory.toJS()).to.deep.equal([new MockLog(0x7776)]);
+		expect(newLogHistory.toJS()).to.deep.equal([new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7776')]);
 		expect(removedLogAnnouncements).to.be.empty;
 	});
 
 	it("removes logs at head for given block", async () => {
 		const removedBlock = new MockBlock(0x7777);
 		const oldLogHistory = Promise.resolve(ImmutableList<Log>([
-			new MockLog(0x7775),
-			new MockLog(0x7776),
-			new MockLog(0x7777),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7775'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7776'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777'),
 		]));
 
 		const newLogHistory = await reconcileLogHistoryWithRemovedBlock(oldLogHistory, removedBlock, onLogRemoved);
 
 		expect(newLogHistory.toJS()).to.deep.equal([
-			new MockLog(0x7775),
-			new MockLog(0x7776),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7775'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7776'),
 		]);
-		expect(removedLogAnnouncements).to.deep.equal([new MockLog(0x7777)]);
+		expect(removedLogAnnouncements).to.deep.equal([new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777')]);
 	});
 
 	it("removes multiple logs in reverse order for same block", async () => {
 		const removedBlock = new MockBlock(0x7777);
 		// NOTE: log index sorting is handled on new block processing but not validated during removal process so out-of-order indexes are only possible by manually creating history
 		const oldLogHistory = Promise.resolve(ImmutableList<Log>([
-			new MockLog(0x7775),
-			new MockLog(0x7776),
-			new MockLog(0x7777, 0x1),
-			new MockLog(0x7777, 0x0),
-			new MockLog(0x7777, 0x2),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7775'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7776'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x1),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x0),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x2),
 		]));
 
 		const newLogHistory = await reconcileLogHistoryWithRemovedBlock(oldLogHistory, removedBlock, onLogRemoved);
 
 		expect(newLogHistory.toJS()).to.deep.equal([
-			new MockLog(0x7775),
-			new MockLog(0x7776),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7775'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7776'),
 		]);
 		expect(removedLogAnnouncements).to.deep.equal([
-			new MockLog(0x7777, 0x2),
-			new MockLog(0x7777, 0x0),
-			new MockLog(0x7777, 0x1),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x2),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x0),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x1),
 		]);
 	});
 
 	it("throws if removed block is not at head", async () => {
 		const removedBlock = new MockBlock(0x7776);
 		const oldLogHistory = Promise.resolve(ImmutableList<Log>([
-			new MockLog(0x7775),
-			new MockLog(0x7776),
-			new MockLog(0x7777),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7775'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7776'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777'),
 		]));
 
 		const newLogHistoryPromise = reconcileLogHistoryWithRemovedBlock(oldLogHistory, removedBlock, onLogRemoved);
@@ -465,19 +465,19 @@ describe("reconcileLogHistoryWithRemovedBlock", async () => {
 	it("removes head logs for block before throwing upon finding nonhead logs for block", async () => {
 		const removedBlock = new MockBlock(0x7777);
 		const oldLogHistory = Promise.resolve(ImmutableList<Log>([
-			new MockLog(0x7775),
-			new MockLog(0x7777),
-			new MockLog(0x7776),
-			new MockLog(0x7777, 0x0),
-			new MockLog(0x7777, 0x1),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7775'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7776'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x0),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x1),
 		]));
 
 		const newLogHistoryPromise = reconcileLogHistoryWithRemovedBlock(oldLogHistory, removedBlock, onLogRemoved);
 
 		await expect(newLogHistoryPromise).to.eventually.rejectedWith(Error, "found logs for removed block not at head of log history");
 		expect(removedLogAnnouncements).to.deep.equal([
-			new MockLog(0x7777, 0x1),
-			new MockLog(0x7777, 0x0),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x1),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0x0),
 		]);
 	});
 });
@@ -510,12 +510,12 @@ describe("BlockAndLogStreamer", async () => {
 
 		expect(announcements).to.deep.equal([
 			{addition: true, item: new MockBlock(0x7777)},
-			{addition: true, item: new MockLog(0x7777, 0)},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0)},
 		]);
 	});
 
 	it("announces removed blocks and logs", async () => {
-		const logs = [ new MockLog(0x7777, 0, 'AAAA'), new MockLog(0x7778, 0, 'AAAA'), new MockLog(0x7778, 0, 'BBBB') ];
+		const logs = [ new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0, 'AAAA'), new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7778', 0, 'AAAA'), new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7778', 0, 'BBBB') ];
 		const getLogs = async (filterOptions: FilterOptions) => [logs.shift()!];
 		reinitialize(getBlockByHashFactory(), getLogs);
 
@@ -526,10 +526,10 @@ describe("BlockAndLogStreamer", async () => {
 		await blockAndLogStreamer.reconcileNewBlock(new MockBlock(0x7778, "BBBB", "AAAA"));
 
 		expect(announcements).to.deep.equal([
-			{addition: false, item: new MockLog(0x7778, 0, 'AAAA')},
+			{addition: false, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7778', 0, 'AAAA')},
 			{addition: false, item: new MockBlock(0x7778, "AAAA", "AAAA")},
 			{addition: true, item: new MockBlock(0x7778, "BBBB", "AAAA")},
-			{addition: true, item: new MockLog(0x7778, 0, 'BBBB')},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7778', 0, 'BBBB')},
 		]);
 	});
 
@@ -544,10 +544,10 @@ describe("BlockAndLogStreamer", async () => {
 
 	it("adding multiple blocks in quick succession results in expected callbacks", async () => {
 		const logs = [
-			new MockLog(0x7777, 0, 'AAAA'),
-			new MockLog(0x7778, 0, 'AAAA'),
-			new MockLog(0x7779, 0, 'AAAA'),
-			new MockLog(0x7779, 0, 'BBBB'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0, 'AAAA'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7778', 0, 'AAAA'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7779', 0, 'AAAA'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7779', 0, 'BBBB'),
 		];
 		const getLogs = async (filterOptions: FilterOptions) => [logs.shift()!];
 		reinitialize(getBlockByHashFactory(), getLogs);
@@ -557,24 +557,24 @@ describe("BlockAndLogStreamer", async () => {
 
 		expect(announcements).to.deep.equal([
 			{addition: true, item: new MockBlock(0x7777, "AAAA", "AAAA")},
-			{addition: true, item: new MockLog(0x7777, 0)},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0)},
 			{addition: true, item: new MockBlock(0x7778, "AAAA", "AAAA")},
-			{addition: true, item: new MockLog(0x7778, 0)},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7778', 0)},
 			{addition: true, item: new MockBlock(0x7779, "AAAA", "AAAA")},
-			{addition: true, item: new MockLog(0x7779, 0)},
-			{addition: false, item: new MockLog(0x7779, 0)},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7779', 0)},
+			{addition: false, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7779', 0)},
 			{addition: false, item: new MockBlock(0x7779, "AAAA", "AAAA")},
 			{addition: true, item: new MockBlock(0x7779, "BBBB", "AAAA")},
-			{addition: true, item: new MockLog(0x7779, 0, "BBBB")},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7779', 0, "BBBB")},
 		]);
 	});
 
 	it("swallows errors from callbacks", async () => {
 		const logs = [
-			new MockLog(0x7777, 0, 'AAAA'),
-			new MockLog(0x7778, 0, 'AAAA'),
-			new MockLog(0x7779, 0, 'AAAA'),
-			new MockLog(0x7779, 0, 'BBBB'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0, 'AAAA'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7778', 0, 'AAAA'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7779', 0, 'AAAA'),
+			new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7779', 0, 'BBBB'),
 		];
 		const getLogs = async (filterOptions: FilterOptions) => [logs.shift()!];
 		reinitialize(getBlockByHashFactory(), getLogs);
@@ -591,23 +591,23 @@ describe("BlockAndLogStreamer", async () => {
 		expect(announcements).to.deep.equal([
 			{addition: true, item: new MockBlock(0x7777, "AAAA", "AAAA")},
 			{addition: true, item: new Error("apple")},
-			{addition: true, item: new MockLog(0x7777, 0)},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0)},
 			{addition: true, item: new Error("cherry")},
 			{addition: true, item: new MockBlock(0x7778, "AAAA", "AAAA")},
 			{addition: true, item: new Error("apple")},
-			{addition: true, item: new MockLog(0x7778, 0)},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7778', 0)},
 			{addition: true, item: new Error("cherry")},
 			{addition: true, item: new MockBlock(0x7779, "AAAA", "AAAA")},
 			{addition: true, item: new Error("apple")},
-			{addition: true, item: new MockLog(0x7779, 0)},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7779', 0)},
 			{addition: true, item: new Error("cherry")},
-			{addition: false, item: new MockLog(0x7779, 0)},
+			{addition: false, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7779', 0)},
 			{addition: true, item: new Error("durian")},
 			{addition: false, item: new MockBlock(0x7779, "AAAA", "AAAA")},
 			{addition: true, item: new Error("banana")},
 			{addition: true, item: new MockBlock(0x7779, "BBBB", "AAAA")},
 			{addition: true, item: new Error("apple")},
-			{addition: true, item: new MockLog(0x7779, 0, "BBBB")},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7779', 0, "BBBB")},
 			{addition: true, item: new Error("cherry")},
 		]);
 	});
@@ -665,26 +665,6 @@ describe("BlockAndLogStreamer", async () => {
 		expect(getLogsCallCount).to.equal(0);
 	});
 
-	it("does not announce or make changes to state if we get logs for wrong block", async () => {
-		const defaultGetLogs = getLogsFactory(1);
-		const forkedGetLogs = getLogsFactory(1, 'BBBB');
-		const getLogs = async (filterOptions: FilterOptions) => (filterOptions.fromBlock === '0x7778' || filterOptions.fromBlock === '0x7779') ? forkedGetLogs(filterOptions) : defaultGetLogs(filterOptions);
-		reinitialize(getBlockByHashFactory([new MockBlock(0x7778, 'BBBB', 'AAAA')]), getLogs);
-
-		await blockAndLogStreamer.reconcileNewBlock(new MockBlock(0x7777));
-		await blockAndLogStreamer.reconcileNewBlock(new MockBlock(0x7778)).catch(() => {});
-		await blockAndLogStreamer.reconcileNewBlock(new MockBlock(0x7779, 'BBBB'));
-
-		expect(announcements).to.deep.equal([
-			{addition: true, item: new MockBlock(0x7777)},
-			{addition: true, item: new MockLog(0x7777, 0)},
-			{addition: true, item: new MockBlock(0x7778, 'BBBB', 'AAAA')},
-			{addition: true, item: new MockLog(0x7778, 0, 'BBBB')},
-			{addition: true, item: new MockBlock(0x7779, 'BBBB')},
-			{addition: true, item: new MockLog(0x7779, 0, 'BBBB')},
-		]);
-	});
-
 	it("does not announce or make changes to state if we can't fetch a parent block", async () => {
 		const defaultGetBlockByHash = getBlockByHashFactory();
 		const getBlockByHash = async (hash: string) => (hash === '0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cBBBB7778') ? null : defaultGetBlockByHash(hash);
@@ -697,11 +677,11 @@ describe("BlockAndLogStreamer", async () => {
 
 		expect(announcements).to.deep.equal([
 			{addition: true, item: new MockBlock(0x7777)},
-			{addition: true, item: new MockLog(0x7777, 0)},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7777', 0)},
 			{addition: true, item: new MockBlock(0x7778)},
-			{addition: true, item: new MockLog(0x7778, 0)},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7778', 0)},
 			{addition: true, item: new MockBlock(0x7779)},
-			{addition: true, item: new MockLog(0x7779, 0)},
+			{addition: true, item: new MockLog('0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cAAAA7779', 0)},
 		]);
 	});
 


### PR DESCRIPTION
This resolves a major source of pain with Blockstream, though it does mean that it depends on very new versions of Geth/Parity that have this functionality.