### PR TITLE
Changes logs added/removed callbacks to receive an array of all logs in a particular block.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockstream",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "description": "A library to turn an unreliable remote source of Ethereum blocks into a reliable stream of blocks with removals on re-orgs and backfills on skips.",
   "main": "output/source/index.js",
   "types": "output/source/index.d.ts",

--- a/source/log-reconciler.ts
+++ b/source/log-reconciler.ts
@@ -8,13 +8,13 @@ export const reconcileLogHistoryWithAddedBlock = async <TBlock extends Block, TL
 	getLogs: (filterOptions: FilterOptions) => Promise<TLog[]>,
 	logHistory: LogHistory<TLog> | Promise<LogHistory<TLog>>,
 	newBlock: TBlock,
-	onLogAdded: (log: TLog) => Promise<void>,
+	onLogsAdded: (blockHash: string, logs: Array<TLog>) => Promise<void>,
 	filters: Filter[] = [],
 	historyBlockLength: number = 100,
 ): Promise<LogHistory<TLog>> => {
 	logHistory = await logHistory;
 	const logs = await getFilteredLogs(getLogs, newBlock, filters);
-	logHistory = await addNewLogsToHead(logHistory, logs, onLogAdded);
+	logHistory = await addNewLogsToHead(newBlock.hash, logHistory, logs, onLogsAdded);
 	logHistory = await pruneOldLogs(logHistory, newBlock, historyBlockLength);
 	return logHistory;
 }
@@ -27,27 +27,24 @@ const getFilteredLogs = async <TBlock extends Block, TLog extends Log>(getLogs: 
 	return nestedLogs.reduce((allLogs, logs) => allLogs.concat(logs), []);
 }
 
-const addNewLogsToHead = async <TLog extends Log>(logHistory: LogHistory<TLog>, newLogs: Array<TLog>, onLogAdded: (log: TLog) => Promise<void>): Promise<LogHistory<TLog>> => {
+const addNewLogsToHead = async <TLog extends Log>(blockHash: string, logHistory: LogHistory<TLog>, newLogs: Array<TLog>, onLogsAdded: (blockHash: string, logs: Array<TLog>) => Promise<void>): Promise<LogHistory<TLog>> => {
 	const sortedLogs = newLogs.sort((logA, logB) => parseHexInt(logA.logIndex) - parseHexInt(logB.logIndex));
+	const addedLogs: Array<TLog> = []
 	for (const logToAdd of sortedLogs) {
 		// we may already have this log because two filters can return the same log
 		if (logHistory.some(logInHistory => logInHistory!.blockHash === logToAdd.blockHash && logInHistory!.logIndex === logToAdd.logIndex)) continue;
 		ensureOrder(logHistory.last(), logToAdd);
-		logHistory = await addNewLogToHead(logHistory, logToAdd, onLogAdded);
+		logHistory = logHistory.push(logToAdd)
+		addedLogs.push(logToAdd)
 	}
+	// CONSIDER: the user getting this notification won't have any visibility into the updated log history yet. should we announce new logs in a `setTimeout`? should we provide log history with new logs?
+	await onLogsAdded(blockHash, addedLogs)
 	return logHistory;
 }
 
 const pruneOldLogs = async <TBlock extends Block, TLog extends Log>(logHistory: LogHistory<TLog>, newBlock: TBlock, historyBlockLength: number): Promise<LogHistory<TLog>> => {
 	// `log!` is required until the next major version of `immutable` is published to NPM (current version 3.8.2) which improves the type definitions
 	return logHistory.skipUntil(log => parseHexInt(newBlock.number) - parseHexInt(log!.blockNumber) < historyBlockLength).toList();
-}
-
-const addNewLogToHead = async <TLog extends Log>(logHistory: LogHistory<TLog>, newLog: TLog, onLogAdded: (log: TLog) => Promise<void>): Promise<LogHistory<TLog>> => {
-	logHistory = logHistory.push(newLog);
-	// CONSIDER: the user getting this notification won't have any visibility into the updated log history yet. should we announce new logs in a `setTimeout`? should we provide log history with new logs?
-	await onLogAdded(newLog);
-	return logHistory;
 }
 
 const ensureOrder = <TLog extends Log>(headLog: TLog | undefined, newLog: TLog) => {
@@ -64,14 +61,16 @@ const ensureOrder = <TLog extends Log>(headLog: TLog | undefined, newLog: TLog) 
 export const reconcileLogHistoryWithRemovedBlock = async <TBlock extends Block, TLog extends Log>(
 	logHistory: LogHistory<TLog>|Promise<LogHistory<TLog>>,
 	removedBlock: TBlock,
-	onLogRemoved: (log: TLog) => Promise<void>,
+	onLogsRemoved: (blockHash: string, logs: Array<TLog>) => Promise<void>,
 ): Promise<LogHistory<TLog>> => {
 	logHistory = await logHistory;
 
+	const removedLogs = []
 	while (!logHistory.isEmpty() && logHistory.last().blockHash === removedBlock.hash) {
-		await onLogRemoved(logHistory.last());
+		removedLogs.push(logHistory.last());
 		logHistory = logHistory.pop();
 	}
+	await onLogsRemoved(removedBlock.hash, removedLogs);
 
 	// sanity check, no known way to trigger the error
 	if (logHistory.some(log => log!.blockHash === removedBlock.hash)) throw new Error("found logs for removed block not at head of log history");


### PR DESCRIPTION
Also fires callback with empty array when block contains no logs matching filters.

Also includes `blockHash` with callback.

This change makes it easier for consumers to know when they are done receiving logs for a particular block.  With this knowledge, they can now process block + logs as a single atomic operation if they desire by saving off the block and waiting for a matching set of logs to come through (or notification of block removal in case log fetching fails).

This change somewhat constrains the problem being solved by this library to just "getting ordering right", rather than trying to provide a nice interface into the stream.  It isn't difficult for users of this library to split apart the logs into multiple callbacks with a _very_ tiny callback wrapper, yet this change opens the doors to a number of new use cases.